### PR TITLE
ENH: use acai.scan to improve JIT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "tqdm",
     "array-api-compat",
     "orng>=0.1.0a7",
-    "acai>=0.1.0a1",
+    "acai-control>=0.1.0a1",
 ]
 
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "tqdm",
     "array-api-compat",
     "orng>=0.1.0a7",
+    "acai>=0.1.0a1",
 ]
 
 dynamic = ["version"]

--- a/src/minipcn/sampler.py
+++ b/src/minipcn/sampler.py
@@ -419,7 +419,6 @@ class Sampler:
         )
         next_carry = rng_state, x, log_prob_x, step_state
         output = {
-            "particles": x,
             "acceptance_rate": chain_state.acceptance_rate,
             "target_acceptance_rate": chain_state.target_acceptance_rate,
             "extra_stats": chain_state.extra_stats,
@@ -440,13 +439,16 @@ class Sampler:
         """Run sampling with backend-appropriate scan control flow."""
 
         def body(carry, iteration):
-            return self._sample_step(
+            next_carry, output = self._sample_step(
                 carry,
                 iteration,
                 rng_backend=rng_backend,
                 step_fn=step_fn,
                 target_acceptance_rate=target_acceptance_rate,
             )
+            if not return_last_only:
+                output = {"particles": next_carry[1], **output}
+            return next_carry, output
 
         iterations = self.xp.arange(n_steps)
         final_carry, outputs = scan(

--- a/src/minipcn/sampler.py
+++ b/src/minipcn/sampler.py
@@ -4,6 +4,7 @@ from typing import Any, Callable
 from warnings import warn
 
 import numpy as np
+from acai import scan
 from array_api_compat import is_jax_namespace
 from orng import RandomGenerator
 from orng.functional import (
@@ -111,6 +112,7 @@ class Sampler:
         seed: int | None = None,
         verbose: bool = True,
         return_last_only: bool = False,
+        use_scan: bool | None = None,
     ) -> tuple[Array, ChainStateHistory]:
         """Run the minipcn sampler.
 
@@ -129,6 +131,12 @@ class Sampler:
         return_last_only:
             If ``True``, return only the final sample batch. Otherwise return
             the full chain history stacked along axis 0.
+        use_scan:
+            Whether to use scan-based control flow. ``None`` selects scan
+            automatically while tracing JAX code, ``False`` always uses the
+            Python loop, and ``True`` always uses scan. Forced scan requires
+            ``verbose=False`` because progress reporting is unavailable inside
+            scan-based control flow.
 
         Returns
         -------
@@ -147,6 +155,7 @@ class Sampler:
             rng_state=rng_state,
             verbose=verbose,
             return_last_only=return_last_only,
+            use_scan=use_scan,
         )
 
         is_tracer = False
@@ -167,6 +176,7 @@ class Sampler:
         rng_state: Any,
         verbose: bool = True,
         return_last_only: bool = False,
+        use_scan: bool | None = None,
     ) -> tuple[Array, ChainStateHistory, Any]:
         """Run the minipcn sampler with an explicit functional RNG state.
 
@@ -189,6 +199,12 @@ class Sampler:
         return_last_only:
             If ``True``, return only the final sample batch. Otherwise return
             the full chain history stacked along axis 0.
+        use_scan:
+            Whether to use scan-based control flow. ``None`` selects scan
+            automatically while tracing JAX code, ``False`` always uses the
+            Python loop, and ``True`` always uses scan. Forced scan requires
+            ``verbose=False`` because progress reporting is unavailable inside
+            scan-based control flow.
 
         Returns
         -------
@@ -208,6 +224,7 @@ class Sampler:
             rng_state=rng_state,
             verbose=verbose,
             return_last_only=return_last_only,
+            use_scan=use_scan,
         )
 
     def _sample_impl(
@@ -219,17 +236,79 @@ class Sampler:
         rng_state: Any,
         verbose: bool,
         return_last_only: bool,
+        use_scan: bool | None,
     ) -> tuple[Array, ChainStateHistory, Any]:
+        if use_scan is True and verbose:
+            raise ValueError("use_scan=True requires verbose=False")
+
+        if use_scan is None and not verbose and is_jax_namespace(self.xp):
+            from ._jax import _contains_tracer
+
+            use_scan = _contains_tracer((x_init, rng_state))
+        elif use_scan is None:
+            use_scan = False
         x = self.xp.atleast_2d(x_init)
         step_fn = self._get_step(rng_backend)
         step_state = step_fn.init_state(x)
         log_prob_x = self.log_prob_fn(x)
+        initial_carry = rng_state, x, log_prob_x, step_state
+        target_acceptance_rate = self.xp.asarray(
+            self.target_acceptance_rate,
+            dtype=x.dtype,
+        )
+
+        if n_steps <= 0:
+            chain = x if return_last_only else self.xp.expand_dims(x, axis=0)
+            history = ChainStateHistory(
+                it=[],
+                acceptance_rate=[],
+                target_acceptance_rate=[],
+                step=step_fn.step_name,
+                extra_stats={},
+            )
+            return chain, history, rng_state
+
+        if use_scan:
+            return self._sample_scan(
+                x_init=x,
+                n_steps=n_steps,
+                rng_backend=rng_backend,
+                initial_carry=initial_carry,
+                step_fn=step_fn,
+                target_acceptance_rate=target_acceptance_rate,
+                return_last_only=return_last_only,
+            )
+
+        return self._sample_loop(
+            x_init=x,
+            n_steps=n_steps,
+            rng_backend=rng_backend,
+            initial_carry=initial_carry,
+            step_fn=step_fn,
+            target_acceptance_rate=target_acceptance_rate,
+            verbose=verbose,
+            return_last_only=return_last_only,
+        )
+
+    def _sample_loop(
+        self,
+        *,
+        x_init: Array,
+        n_steps: int,
+        rng_backend: Any,
+        initial_carry: tuple[Any, Array, Array, Any],
+        step_fn: Step,
+        target_acceptance_rate: Array,
+        verbose: bool,
+        return_last_only: bool,
+    ) -> tuple[Array, ChainStateHistory, Any]:
+        carry = initial_carry
 
         chain_states: list[Array] | None
         if return_last_only:
             chain_states = None
         else:
-            chain_states = [x]
+            chain_states = [x_init]
 
         history_states: list[ChainState] = []
 
@@ -238,45 +317,24 @@ class Sampler:
             iterator = trange(n_steps, desc="Sampling", unit="step")
 
         for i in iterator:
-            rng_state, x_new, log_alpha_step = step_fn.propose(
-                step_state,
-                rng_state,
-                x,
+            carry, output = self._sample_step(
+                carry,
+                i,
+                rng_backend=rng_backend,
+                step_fn=step_fn,
+                target_acceptance_rate=target_acceptance_rate,
             )
-            log_prob_x_new = self.log_prob_fn(x_new)
-            log_alpha = log_prob_x_new - log_prob_x + log_alpha_step
-            alpha = self.xp.exp(
-                self.xp.minimum(
-                    self.xp.asarray(0.0, dtype=log_alpha.dtype),
-                    log_alpha,
-                )
-            )
-
-            uniform, rng_state = rng_backend.uniform(
-                rng_state,
-                low=0.0,
-                high=1.0,
-                size=(x_new.shape[0],),
-                dtype=x_new.dtype,
-            )
-            accept = uniform < alpha
-            x = self.xp.where(accept[:, None], x_new, x)
-            log_prob_x = self.xp.where(accept, log_prob_x_new, log_prob_x)
+            rng_state, x, _, _ = carry
 
             if chain_states is not None:
                 chain_states.append(x)
 
-            acceptance_rate = self.xp.sum(accept) / accept.shape[0]
             chain_state = ChainState(
                 it=i,
-                acceptance_rate=acceptance_rate,
-                target_acceptance_rate=self.target_acceptance_rate,
+                acceptance_rate=output["acceptance_rate"],
+                target_acceptance_rate=output["target_acceptance_rate"],
                 step=step_fn.step_name,
-            )
-            step_state, chain_state = step_fn.adapt(
-                step_state,
-                chain_state,
-                samples=x,
+                extra_stats=output["extra_stats"],
             )
             history_states.append(chain_state)
 
@@ -310,6 +368,112 @@ class Sampler:
                 step=step_fn.step_name,
                 extra_stats={},
             )
+        return chain, history, rng_state
+
+    def _sample_step(
+        self,
+        carry: tuple[Any, Array, Array, Any],
+        iteration: Any,
+        *,
+        rng_backend: Any,
+        step_fn: Step,
+        target_acceptance_rate: Array,
+    ) -> tuple[tuple[Any, Array, Array, Any], dict[str, Any]]:
+        rng_state, x, log_prob_x, step_state = carry
+        rng_state, x_new, log_alpha_step = step_fn.propose(
+            step_state,
+            rng_state,
+            x,
+        )
+        log_prob_x_new = self.log_prob_fn(x_new)
+        log_alpha = log_prob_x_new - log_prob_x + log_alpha_step
+        alpha = self.xp.exp(
+            self.xp.minimum(
+                self.xp.asarray(0.0, dtype=log_alpha.dtype),
+                log_alpha,
+            )
+        )
+
+        uniform, rng_state = rng_backend.uniform(
+            rng_state,
+            low=0.0,
+            high=1.0,
+            size=(x_new.shape[0],),
+            dtype=x_new.dtype,
+        )
+        accept = uniform < alpha
+        x = self.xp.where(accept[:, None], x_new, x)
+        log_prob_x = self.xp.where(accept, log_prob_x_new, log_prob_x)
+
+        acceptance_rate = self.xp.sum(accept) / accept.shape[0]
+        chain_state = ChainState(
+            it=iteration,
+            acceptance_rate=acceptance_rate,
+            target_acceptance_rate=target_acceptance_rate,
+            step=step_fn.step_name,
+        )
+        step_state, chain_state = step_fn.adapt(
+            step_state,
+            chain_state,
+            samples=x,
+        )
+        next_carry = rng_state, x, log_prob_x, step_state
+        output = {
+            "particles": x,
+            "acceptance_rate": chain_state.acceptance_rate,
+            "target_acceptance_rate": chain_state.target_acceptance_rate,
+            "extra_stats": chain_state.extra_stats,
+        }
+        return next_carry, output
+
+    def _sample_scan(
+        self,
+        *,
+        x_init: Array,
+        n_steps: int,
+        rng_backend: Any,
+        initial_carry: tuple[Any, Array, Array, Any],
+        step_fn: Step,
+        target_acceptance_rate: Array,
+        return_last_only: bool,
+    ) -> tuple[Array, ChainStateHistory, Any]:
+        """Run sampling with backend-appropriate scan control flow."""
+
+        def body(carry, iteration):
+            return self._sample_step(
+                carry,
+                iteration,
+                rng_backend=rng_backend,
+                step_fn=step_fn,
+                target_acceptance_rate=target_acceptance_rate,
+            )
+
+        iterations = self.xp.arange(n_steps)
+        final_carry, outputs = scan(
+            body,
+            initial_carry,
+            iterations,
+            xp=self.xp,
+        )
+        rng_state, x, _, _ = final_carry
+
+        if return_last_only:
+            chain = x
+        else:
+            chain = self.xp.concat(
+                (
+                    self.xp.expand_dims(x_init, axis=0),
+                    outputs["particles"],
+                ),
+                axis=0,
+            )
+        history = ChainStateHistory(
+            it=iterations,
+            acceptance_rate=outputs["acceptance_rate"],
+            target_acceptance_rate=outputs["target_acceptance_rate"],
+            step=step_fn.step_name,
+            extra_stats=outputs["extra_stats"],
+        )
         return chain, history, rng_state
 
     def _get_step(self, rng_backend: Any) -> Step:

--- a/tests/integration_tests/test_sampling.py
+++ b/tests/integration_tests/test_sampling.py
@@ -1,26 +1,10 @@
+import numpy as np
 import pytest
 
 from minipcn import Sampler
 
 
-def test_sampling(rng, log_target_fn, step_fn, dims, xp):
-    x_init = rng.normal(size=(100, dims))  # Initial samples
-
-    sampler = Sampler(
-        log_prob_fn=log_target_fn,
-        dims=dims,
-        step_fn=step_fn,
-        target_acceptance_rate=0.234,
-        xp=xp,
-    )
-
-    chain, history = sampler.sample(x_init, n_steps=100, rng=rng)
-    assert chain.shape == (101, 100, dims)
-    assert history.it[-1] == 99
-
-
-@pytest.mark.parametrize("step_fn", ["pCN", "tpCN"])
-def test_sampling_jax_jit_return_last_only(step_fn):
+def _make_jax_sampler(step_fn):
     jax = pytest.importorskip("jax")
     jnp = pytest.importorskip("jax.numpy")
     from orng.functional import create_functional_backend
@@ -46,8 +30,29 @@ def test_sampling_jax_jit_return_last_only(step_fn):
         target_acceptance_rate=0.234,
         xp=jnp,
     )
+    return jax, jnp, sampler, x_init, rng_state
 
-    @jax.jit
+
+def test_sampling(rng, log_target_fn, step_fn, dims, xp):
+    x_init = rng.normal(size=(100, dims))  # Initial samples
+
+    sampler = Sampler(
+        log_prob_fn=log_target_fn,
+        dims=dims,
+        step_fn=step_fn,
+        target_acceptance_rate=0.234,
+        xp=xp,
+    )
+
+    chain, history = sampler.sample(x_init, n_steps=100, rng=rng)
+    assert chain.shape == (101, 100, dims)
+    assert history.it[-1] == 99
+
+
+@pytest.mark.parametrize("step_fn", ["pCN", "tpCN"])
+def test_sampling_jax_jit_return_last_only(step_fn):
+    jax, _, sampler, x_init, rng_state = _make_jax_sampler(step_fn)
+
     def run(x0, state):
         samples, history, _ = sampler.sample_functional(
             x0,
@@ -58,16 +63,103 @@ def test_sampling_jax_jit_return_last_only(step_fn):
         )
         return samples, history
 
-    final_samples, history = run(x_init, rng_state)
+    jaxpr = jax.make_jaxpr(run)(x_init, rng_state)
+    assert "scan" in {equation.primitive.name for equation in jaxpr.jaxpr.eqns}
+
+    final_samples, history = jax.jit(run)(x_init, rng_state)
     assert final_samples.shape == x_init.shape
     assert final_samples.dtype == x_init.dtype
     assert history.it.shape == (8,)
     assert history.acceptance_rate.shape == (8,)
 
 
+def test_sampling_jax_jit_scan_can_be_disabled():
+    jax, _, sampler, x_init, rng_state = _make_jax_sampler("pCN")
+
+    def run(x0, state):
+        return sampler.sample_functional(
+            x0,
+            n_steps=8,
+            rng_state=state,
+            verbose=False,
+            return_last_only=True,
+            use_scan=False,
+        )
+
+    jaxpr = jax.make_jaxpr(run)(x_init, rng_state)
+    assert "scan" not in {
+        equation.primitive.name for equation in jaxpr.jaxpr.eqns
+    }
+
+    final_samples, history, _ = jax.jit(run)(x_init, rng_state)
+    assert final_samples.shape == x_init.shape
+    assert history.it.shape == (8,)
+
+
+@pytest.mark.parametrize("step_fn", ["pCN", "tpCN"])
+def test_sampling_jax_scan_matches_loop(step_fn):
+    jax, _, sampler, x_init, rng_state = _make_jax_sampler(step_fn)
+
+    scan_chain, scan_history, scan_rng_state = sampler.sample_functional(
+        x_init,
+        n_steps=8,
+        rng_state=rng_state,
+        verbose=False,
+        use_scan=True,
+    )
+    loop_chain, loop_history, loop_rng_state = sampler.sample_functional(
+        x_init,
+        n_steps=8,
+        rng_state=rng_state,
+        verbose=False,
+        use_scan=False,
+    )
+
+    np.testing.assert_allclose(scan_chain, loop_chain, rtol=1e-5, atol=1e-6)
+    np.testing.assert_array_equal(scan_history.it, loop_history.it)
+    np.testing.assert_allclose(
+        scan_history.acceptance_rate,
+        loop_history.acceptance_rate,
+        rtol=1e-5,
+        atol=1e-6,
+    )
+    np.testing.assert_allclose(
+        scan_history.target_acceptance_rate,
+        loop_history.target_acceptance_rate,
+        rtol=1e-5,
+        atol=1e-6,
+    )
+    assert scan_history.step == loop_history.step
+    assert scan_history.extra_stats.keys() == loop_history.extra_stats.keys()
+    for key in scan_history.extra_stats:
+        np.testing.assert_allclose(
+            scan_history.extra_stats[key],
+            loop_history.extra_stats[key],
+            rtol=1e-5,
+            atol=1e-6,
+        )
+    np.testing.assert_array_equal(
+        jax.random.key_data(scan_rng_state),
+        jax.random.key_data(loop_rng_state),
+    )
+
+
+def test_forced_scan_rejects_verbose_output():
+    _, _, sampler, x_init, rng_state = _make_jax_sampler("pCN")
+
+    with pytest.raises(
+        ValueError, match="use_scan=True requires verbose=False"
+    ):
+        sampler.sample_functional(
+            x_init,
+            n_steps=8,
+            rng_state=rng_state,
+            use_scan=True,
+        )
+
+
 def test_sampling_with_functional_backend_input():
     pytest.importorskip("numpy")
-    import numpy as np
     from orng.functional import create_functional_backend
 
     dims = 2

--- a/tests/integration_tests/test_sampling.py
+++ b/tests/integration_tests/test_sampling.py
@@ -64,7 +64,15 @@ def test_sampling_jax_jit_return_last_only(step_fn):
         return samples, history
 
     jaxpr = jax.make_jaxpr(run)(x_init, rng_state)
-    assert "scan" in {equation.primitive.name for equation in jaxpr.jaxpr.eqns}
+    scan_equation = next(
+        equation
+        for equation in jaxpr.jaxpr.eqns
+        if equation.primitive.name == "scan"
+    )
+    particle_history_shape = (8, *x_init.shape)
+    assert particle_history_shape not in {
+        variable.aval.shape for variable in scan_equation.outvars
+    }
 
     final_samples, history = jax.jit(run)(x_init, rng_state)
     assert final_samples.shape == x_init.shape


### PR DESCRIPTION
Uses the `acai` library to improve JIT compilation.

See https://github.com/sequince-dev/acai