### PR TITLE
BUG: safeguard Student-t degrees-of-freedom root finding

### DIFF
--- a/src/minipcn/_jax.py
+++ b/src/minipcn/_jax.py
@@ -6,7 +6,12 @@ import jax.scipy.special as jsp
 from array_api_compat import device as get_device
 
 from ._typing import Array
-from .student_t import _nu_value, _prepare_samples
+from .student_t import (
+    _NU_SOLVER_MAX_ITER,
+    _NU_SOLVER_TOL,
+    _nu_value,
+    _prepare_samples,
+)
 
 
 def _is_tracer(value: Any) -> bool:
@@ -49,6 +54,10 @@ def fit_student_t_em(
     dims_value = jnp.asarray(dims, **asarray_kwargs)
     one = jnp.asarray(1, **asarray_kwargs)
     tol_value = jnp.asarray(tol, **asarray_kwargs)
+    root_tol_value = jnp.maximum(
+        jnp.asarray(_NU_SOLVER_TOL, **asarray_kwargs),
+        jnp.asarray(jnp.finfo(dtype).eps, **asarray_kwargs),
+    )
     eye = jnp.eye(dims, **asarray_kwargs)
     ridge_factor = jnp.asarray(
         max(1e-9, 10 * jnp.finfo(dtype).eps),
@@ -69,19 +78,22 @@ def fit_student_t_em(
         return jnp.sum(solved**2, axis=0)
 
     def solve_nu(nu, avg_term):
-        eps = jnp.asarray(jnp.finfo(dtype).eps, **asarray_kwargs)
         eta_min = jnp.log(jnp.asarray(1e-3, **asarray_kwargs))
         eta_max = jnp.log(jnp.asarray(1e6, **asarray_kwargs))
 
-        def body(_, eta):
-            nu_current = jnp.exp(eta)
-            value = _nu_value(
-                nu_current,
-                avg_term,
-                dims_value,
-                xp=jnp,
-                digamma=jsp.digamma,
+        def condition(state):
+            iteration, _, _, _, value = state
+            return (
+                (iteration < _NU_SOLVER_MAX_ITER)
+                & jnp.isfinite(value)
+                & (jnp.abs(value) > root_tol_value)
             )
+
+        def body(state):
+            iteration, eta, eta_min, eta_max, value = state
+            nu_current = jnp.exp(eta)
+            eta_min = jnp.where(value > 0, eta, eta_min)
+            eta_max = jnp.where(value > 0, eta_max, eta)
             derivative = (
                 -0.5 * jsp.polygamma(1, nu_current / 2)
                 + 1 / nu_current
@@ -92,33 +104,61 @@ def fit_student_t_em(
             safe = (
                 jnp.isfinite(value)
                 & jnp.isfinite(denominator)
-                & (jnp.abs(denominator) > eps)
+                & (denominator != 0)
             )
-            step = jnp.where(safe, value / denominator, 0)
+            safe_denominator = jnp.where(safe, denominator, 1)
+            step = jnp.where(safe, value / safe_denominator, 0)
             step = jnp.clip(step, -2.0, 2.0)
-            candidate = jnp.clip(eta - step, eta_min, eta_max)
-            return jnp.where(jnp.isfinite(candidate), candidate, eta)
-
-        initial_residual = jnp.abs(
-            _nu_value(
-                nu,
+            newton_candidate = eta - step
+            # Use Newton only when its step is finite and remains inside the
+            # root bracket; otherwise bisect the bracket to guarantee progress.
+            use_newton = (
+                safe
+                & jnp.isfinite(newton_candidate)
+                & (newton_candidate > eta_min)
+                & (newton_candidate < eta_max)
+            )
+            candidate = jnp.where(
+                use_newton,
+                newton_candidate,
+                0.5 * (eta_min + eta_max),
+            )
+            candidate_value = _nu_value(
+                jnp.exp(candidate),
                 avg_term,
                 dims_value,
                 xp=jnp,
                 digamma=jsp.digamma,
             )
-        )
-        eta = jax.lax.fori_loop(0, 12, body, jnp.log(nu))
-        candidate = jnp.exp(eta)
-        final_residual = jnp.abs(
-            _nu_value(
+            return (
+                iteration + 1,
                 candidate,
-                avg_term,
-                dims_value,
-                xp=jnp,
-                digamma=jsp.digamma,
+                eta_min,
+                eta_max,
+                candidate_value,
             )
+
+        initial_value = _nu_value(
+            nu,
+            avg_term,
+            dims_value,
+            xp=jnp,
+            digamma=jsp.digamma,
         )
+        initial_residual = jnp.abs(initial_value)
+        _, eta, _, _, final_value = jax.lax.while_loop(
+            condition,
+            body,
+            (
+                jnp.asarray(0),
+                jnp.log(nu),
+                eta_min,
+                eta_max,
+                initial_value,
+            ),
+        )
+        candidate = jnp.exp(eta)
+        final_residual = jnp.abs(final_value)
         improved = jnp.isfinite(final_residual) & (
             final_residual <= initial_residual
         )

--- a/src/minipcn/_jax.py
+++ b/src/minipcn/_jax.py
@@ -36,6 +36,115 @@ def _register_dataclass(*args, **kwargs):
     return jax.tree_util.register_dataclass(*args, **kwargs)
 
 
+def _solve_nu(
+    nu,
+    avg_term,
+    dims,
+    *,
+    max_iter: int = _NU_SOLVER_MAX_ITER,
+    tol: float = _NU_SOLVER_TOL,
+):
+    """Solve the Student-t degrees-of-freedom equation in log-space."""
+    dtype = nu.dtype
+    asarray_kwargs: dict[str, Any] = {"dtype": dtype}
+    device = get_device(nu)
+    if device is not None:
+        asarray_kwargs["device"] = device
+
+    dims_value = jnp.asarray(dims, **asarray_kwargs)
+    tolerance = jnp.maximum(
+        jnp.asarray(tol, **asarray_kwargs),
+        jnp.asarray(jnp.finfo(dtype).eps, **asarray_kwargs),
+    )
+    eta_min = jnp.log(jnp.asarray(1e-3, **asarray_kwargs))
+    eta_max = jnp.log(jnp.asarray(1e6, **asarray_kwargs))
+    eta = jnp.clip(jnp.log(nu), eta_min, eta_max)
+    nu_initial = jnp.exp(eta)
+
+    def condition(state):
+        iteration, _, _, _, value = state
+        return (
+            (iteration < max_iter)
+            & jnp.isfinite(value)
+            & (jnp.abs(value) > tolerance)
+        )
+
+    def body(state):
+        iteration, eta, eta_min, eta_max, value = state
+        nu_current = jnp.exp(eta)
+        eta_min = jnp.where(value > 0, eta, eta_min)
+        eta_max = jnp.where(value > 0, eta_max, eta)
+        derivative = (
+            -0.5 * jsp.polygamma(1, nu_current / 2)
+            + 1 / nu_current
+            + 0.5 * jsp.polygamma(1, (nu_current + dims_value) / 2)
+            - 1 / (nu_current + dims_value)
+        )
+        denominator = nu_current * derivative
+        safe = (
+            jnp.isfinite(value)
+            & jnp.isfinite(denominator)
+            & (denominator != 0)
+        )
+        safe_denominator = jnp.where(safe, denominator, 1)
+        step = jnp.where(safe, value / safe_denominator, 0)
+        step = jnp.clip(step, -2.0, 2.0)
+        newton_candidate = eta - step
+        # Use Newton only when its step is finite and remains inside the
+        # current search interval; otherwise bisect the interval.
+        use_newton = (
+            safe
+            & jnp.isfinite(newton_candidate)
+            & (newton_candidate > eta_min)
+            & (newton_candidate < eta_max)
+        )
+        candidate = jnp.where(
+            use_newton,
+            newton_candidate,
+            0.5 * (eta_min + eta_max),
+        )
+        candidate_value = _nu_value(
+            jnp.exp(candidate),
+            avg_term,
+            dims_value,
+            xp=jnp,
+            digamma=jsp.digamma,
+        )
+        return (
+            iteration + 1,
+            candidate,
+            eta_min,
+            eta_max,
+            candidate_value,
+        )
+
+    initial_value = _nu_value(
+        nu_initial,
+        avg_term,
+        dims_value,
+        xp=jnp,
+        digamma=jsp.digamma,
+    )
+    initial_residual = jnp.abs(initial_value)
+    _, eta, _, _, final_value = jax.lax.while_loop(
+        condition,
+        body,
+        (
+            jnp.asarray(0),
+            eta,
+            eta_min,
+            eta_max,
+            initial_value,
+        ),
+    )
+    candidate = jnp.exp(eta)
+    final_residual = jnp.abs(final_value)
+    improved = jnp.isfinite(final_residual) & (
+        final_residual <= initial_residual
+    )
+    return jnp.where(improved, candidate, nu_initial)
+
+
 def fit_student_t_em(
     x: Array,
     nu_init: float,
@@ -54,10 +163,6 @@ def fit_student_t_em(
     dims_value = jnp.asarray(dims, **asarray_kwargs)
     one = jnp.asarray(1, **asarray_kwargs)
     tol_value = jnp.asarray(tol, **asarray_kwargs)
-    root_tol_value = jnp.maximum(
-        jnp.asarray(_NU_SOLVER_TOL, **asarray_kwargs),
-        jnp.asarray(jnp.finfo(dtype).eps, **asarray_kwargs),
-    )
     eye = jnp.eye(dims, **asarray_kwargs)
     ridge_factor = jnp.asarray(
         max(1e-9, 10 * jnp.finfo(dtype).eps),
@@ -76,93 +181,6 @@ def fit_student_t_em(
             jnp.permute_dims(diff, (1, 0)),
         )
         return jnp.sum(solved**2, axis=0)
-
-    def solve_nu(nu, avg_term):
-        eta_min = jnp.log(jnp.asarray(1e-3, **asarray_kwargs))
-        eta_max = jnp.log(jnp.asarray(1e6, **asarray_kwargs))
-
-        def condition(state):
-            iteration, _, _, _, value = state
-            return (
-                (iteration < _NU_SOLVER_MAX_ITER)
-                & jnp.isfinite(value)
-                & (jnp.abs(value) > root_tol_value)
-            )
-
-        def body(state):
-            iteration, eta, eta_min, eta_max, value = state
-            nu_current = jnp.exp(eta)
-            eta_min = jnp.where(value > 0, eta, eta_min)
-            eta_max = jnp.where(value > 0, eta_max, eta)
-            derivative = (
-                -0.5 * jsp.polygamma(1, nu_current / 2)
-                + 1 / nu_current
-                + 0.5 * jsp.polygamma(1, (nu_current + dims_value) / 2)
-                - 1 / (nu_current + dims_value)
-            )
-            denominator = nu_current * derivative
-            safe = (
-                jnp.isfinite(value)
-                & jnp.isfinite(denominator)
-                & (denominator != 0)
-            )
-            safe_denominator = jnp.where(safe, denominator, 1)
-            step = jnp.where(safe, value / safe_denominator, 0)
-            step = jnp.clip(step, -2.0, 2.0)
-            newton_candidate = eta - step
-            # Use Newton only when its step is finite and remains inside the
-            # root bracket; otherwise bisect the bracket to guarantee progress.
-            use_newton = (
-                safe
-                & jnp.isfinite(newton_candidate)
-                & (newton_candidate > eta_min)
-                & (newton_candidate < eta_max)
-            )
-            candidate = jnp.where(
-                use_newton,
-                newton_candidate,
-                0.5 * (eta_min + eta_max),
-            )
-            candidate_value = _nu_value(
-                jnp.exp(candidate),
-                avg_term,
-                dims_value,
-                xp=jnp,
-                digamma=jsp.digamma,
-            )
-            return (
-                iteration + 1,
-                candidate,
-                eta_min,
-                eta_max,
-                candidate_value,
-            )
-
-        initial_value = _nu_value(
-            nu,
-            avg_term,
-            dims_value,
-            xp=jnp,
-            digamma=jsp.digamma,
-        )
-        initial_residual = jnp.abs(initial_value)
-        _, eta, _, _, final_value = jax.lax.while_loop(
-            condition,
-            body,
-            (
-                jnp.asarray(0),
-                jnp.log(nu),
-                eta_min,
-                eta_max,
-                initial_value,
-            ),
-        )
-        candidate = jnp.exp(eta)
-        final_residual = jnp.abs(final_value)
-        improved = jnp.isfinite(final_residual) & (
-            final_residual <= initial_residual
-        )
-        return jnp.where(improved, candidate, nu)
 
     mu = jnp.mean(x, axis=0)
     centered = x - mu
@@ -193,7 +211,7 @@ def fit_student_t_em(
 
         nu_weights = (nu + dims_value) / (nu + delta_new)
         avg_term = jnp.mean(jnp.log(nu_weights) - nu_weights)
-        nu_new = solve_nu(nu, avg_term)
+        nu_new = _solve_nu(nu, avg_term, dims_value)
 
         error = jnp.maximum(
             jnp.max(jnp.abs(mu_new - mu)),

--- a/src/minipcn/student_t.py
+++ b/src/minipcn/student_t.py
@@ -6,6 +6,9 @@ from scipy.special import polygamma, psi
 
 from ._typing import Array
 
+_NU_SOLVER_MAX_ITER = 50
+_NU_SOLVER_TOL = 1e-8
+
 
 def _prepare_samples(x: Array, xp: Any) -> Array:
     if x.ndim == 1:
@@ -39,11 +42,13 @@ def _solve_nu(
     xp,
     digamma,
     trigamma,
-    max_iter: int = 12,
+    max_iter: int = _NU_SOLVER_MAX_ITER,
+    tol: float = _NU_SOLVER_TOL,
 ):
     """Solve the Student-t degrees-of-freedom equation in log-space."""
     dtype = nu.dtype
     eps = xp.asarray(xp.finfo(dtype).eps, dtype=dtype)
+    tolerance = xp.maximum(xp.asarray(tol, dtype=dtype), eps)
     eta_min = xp.log(xp.asarray(1e-3, dtype=dtype))
     eta_max = xp.log(xp.asarray(1e6, dtype=dtype))
     eta = xp.log(nu)
@@ -66,6 +71,10 @@ def _solve_nu(
             xp=xp,
             digamma=digamma,
         )
+        if bool(xp.abs(value) <= tolerance):
+            break
+        eta_min = xp.where(value > 0, eta, eta_min)
+        eta_max = xp.where(value > 0, eta_max, eta)
         derivative = (
             -0.5 * trigamma(nu_current / 2)
             + 1 / nu_current
@@ -75,12 +84,37 @@ def _solve_nu(
         denominator = nu_current * derivative
         safe = xp.logical_and(
             xp.logical_and(xp.isfinite(value), xp.isfinite(denominator)),
-            xp.abs(denominator) > eps,
+            denominator != xp.zeros_like(denominator),
         )
-        step = xp.where(safe, value / denominator, xp.zeros_like(value))
+        safe_denominator = xp.where(
+            safe,
+            denominator,
+            xp.ones_like(denominator),
+        )
+        step = xp.where(
+            safe,
+            value / safe_denominator,
+            xp.zeros_like(value),
+        )
         step = xp.clip(step, -2.0, 2.0)
-        candidate = xp.clip(eta - step, eta_min, eta_max)
-        eta = xp.where(xp.isfinite(candidate), candidate, eta)
+        newton_candidate = eta - step
+        # Use Newton only when its step is finite and remains inside the root
+        # bracket; otherwise bisect the bracket to guarantee progress.
+        use_newton = xp.logical_and(
+            safe,
+            xp.logical_and(
+                xp.isfinite(newton_candidate),
+                xp.logical_and(
+                    newton_candidate > eta_min,
+                    newton_candidate < eta_max,
+                ),
+            ),
+        )
+        eta = xp.where(
+            use_newton,
+            newton_candidate,
+            0.5 * (eta_min + eta_max),
+        )
 
     candidate = xp.exp(eta)
     final_residual = xp.abs(

--- a/src/minipcn/student_t.py
+++ b/src/minipcn/student_t.py
@@ -51,10 +51,11 @@ def _solve_nu(
     tolerance = xp.maximum(xp.asarray(tol, dtype=dtype), eps)
     eta_min = xp.log(xp.asarray(1e-3, dtype=dtype))
     eta_max = xp.log(xp.asarray(1e6, dtype=dtype))
-    eta = xp.log(nu)
+    eta = xp.clip(xp.log(nu), eta_min, eta_max)
+    nu_initial = xp.exp(eta)
     initial_residual = xp.abs(
         _nu_value(
-            nu,
+            nu_initial,
             avg_term,
             dims,
             xp=xp,
@@ -98,8 +99,8 @@ def _solve_nu(
         )
         step = xp.clip(step, -2.0, 2.0)
         newton_candidate = eta - step
-        # Use Newton only when its step is finite and remains inside the root
-        # bracket; otherwise bisect the bracket to guarantee progress.
+        # Use Newton only when its step is finite and remains inside the
+        # current search interval; otherwise bisect the interval.
         use_newton = xp.logical_and(
             safe,
             xp.logical_and(
@@ -130,7 +131,7 @@ def _solve_nu(
         xp.isfinite(final_residual),
         final_residual <= initial_residual,
     )
-    return xp.where(improved, candidate, nu)
+    return xp.where(improved, candidate, nu_initial)
 
 
 def _fit_eager(

--- a/tests/test_utils/test_fit_student_t.py
+++ b/tests/test_utils/test_fit_student_t.py
@@ -12,6 +12,8 @@ from minipcn.utils import to_numpy_array
         (np.float64, 1e-3, -1.001, 1000, 618.3671231438226),
         (np.float32, 1e5, -1.1, 10, 6.492608031799467),
         (np.float32, 1e6, -1.8, 1000, 1.4953490086755392),
+        (np.float32, 1e-6, -1.8, 1000, 1.4953490086755392),
+        (np.float32, 1e9, -1.1, 10, 6.492608031799467),
     ],
 )
 def test_solve_nu_converges_from_distant_initial_value(
@@ -45,6 +47,44 @@ def test_solve_nu_converges_from_distant_initial_value(
 
     np.testing.assert_allclose(result, expected, rtol=5e-6)
     assert abs(float(residual)) <= max(1e-8, np.finfo(dtype).eps)
+
+
+@pytest.mark.parametrize(
+    ("nu_init", "avg_term", "dims", "expected"),
+    [
+        (1e5, -1.1, 10, 6.492608031799467),
+        (1e6, -1.8, 1000, 1.4953490086755392),
+        (1e-6, -1.8, 1000, 1.4953490086755392),
+        (1e9, -1.1, 10, 6.492608031799467),
+    ],
+)
+def test_solve_nu_jax_converges(
+    nu_init,
+    avg_term,
+    dims,
+    expected,
+):
+    jax = pytest.importorskip("jax")
+    jnp = pytest.importorskip("jax.numpy")
+    jsp = pytest.importorskip("jax.scipy.special")
+    from minipcn._jax import _solve_nu as solve_nu_jax
+
+    dtype = jnp.float32
+    nu = jnp.asarray(nu_init, dtype=dtype)
+    avg = jnp.asarray(avg_term, dtype=dtype)
+    dims_value = jnp.asarray(dims, dtype=dtype)
+
+    result = jax.jit(solve_nu_jax)(nu, avg, dims_value)
+    residual = _nu_value(
+        result,
+        avg,
+        dims_value,
+        xp=jnp,
+        digamma=jsp.digamma,
+    )
+
+    np.testing.assert_allclose(result, expected, rtol=5e-6)
+    assert abs(float(residual)) <= max(1e-8, np.finfo(np.float32).eps)
 
 
 @pytest.mark.parametrize("dims", [1, 2])

--- a/tests/test_utils/test_fit_student_t.py
+++ b/tests/test_utils/test_fit_student_t.py
@@ -1,8 +1,50 @@
 import numpy as np
 import pytest
+from scipy.special import polygamma, psi
 
-from minipcn.student_t import fit_student_t_em
+from minipcn.student_t import _nu_value, _solve_nu, fit_student_t_em
 from minipcn.utils import to_numpy_array
+
+
+@pytest.mark.parametrize(
+    ("dtype", "nu_init", "avg_term", "dims", "expected"),
+    [
+        (np.float64, 1e-3, -1.001, 1000, 618.3671231438226),
+        (np.float32, 1e5, -1.1, 10, 6.492608031799467),
+        (np.float32, 1e6, -1.8, 1000, 1.4953490086755392),
+    ],
+)
+def test_solve_nu_converges_from_distant_initial_value(
+    dtype, nu_init, avg_term, dims, expected
+):
+    def digamma(value):
+        return np.asarray(psi(value), dtype=dtype)
+
+    def trigamma(value):
+        return np.asarray(polygamma(1, value), dtype=dtype)
+
+    nu = np.asarray(nu_init, dtype=dtype)
+    avg = np.asarray(avg_term, dtype=dtype)
+    dims_value = np.asarray(dims, dtype=dtype)
+
+    result = _solve_nu(
+        nu,
+        avg,
+        dims_value,
+        xp=np,
+        digamma=digamma,
+        trigamma=trigamma,
+    )
+    residual = _nu_value(
+        result,
+        avg,
+        dims_value,
+        xp=np,
+        digamma=digamma,
+    )
+
+    np.testing.assert_allclose(result, expected, rtol=5e-6)
+    assert abs(float(residual)) <= max(1e-8, np.finfo(dtype).eps)
 
 
 @pytest.mark.parametrize("dims", [1, 2])


### PR DESCRIPTION
Increase the iteration limit, stop on convergence, and fall back to
bisection when a Newton step is invalid or leaves the root bracket.

This prevents premature termination and float32 stalls.

This should address the issue reported by @GregoryAshton.